### PR TITLE
Fix for LMXRLF

### DIFF
--- a/Source/lmxrlf.cpp
+++ b/Source/lmxrlf.cpp
@@ -25,12 +25,12 @@ vector<string> GraphColoring::Lmxrlf::get_independent(vector<string> set) {
 	}
 	vector<string> ret;
 	for(map< string, vector<string> >::iterator i = graph.begin(); i != graph.end(); i++) {
-		if(graph_colors[(*i).first] == -1) {
+		if(this->graph_colors[i->first] == -1) {
 			int flag = 0;
 			for(unsigned j=0; j<delta.size(); j++) {
-				if(delta[j] == (*i).first) { flag = 1; }
+				if(delta[j] == i->first) { flag = 1; }
 			}
-			if(!flag) { ret.push_back((*i).first); }
+			if(!flag) { ret.push_back(i->first); }
 		}
 	}
 	return ret;
@@ -149,7 +149,7 @@ vector<string> GraphColoring::Lmxrlf::uncolored_neighbor(vector<string> new_set)
 	for(map< string, vector<string> >::iterator i = graph.begin(); i != graph.end(); i++) {
 		int initf = 1;
 		for(unsigned j=0; j<delta.size(); j++) {
-			if((*i).first == delta[j]) {
+			if(i->first == delta[j]) {
 				initf = 0;
 			}
 		}
@@ -157,13 +157,13 @@ vector<string> GraphColoring::Lmxrlf::uncolored_neighbor(vector<string> new_set)
 			int count = 0;
 			for(unsigned j=0; j<(*i).second.size(); j++) {
 				for(unsigned y=0; y<delta.size(); y++) {
-					if((*i).second[j] == delta[y]) {
+					if(i->second[j] == delta[y]) {
 						count += 1;
 					}
 				}
 			}
-			if(count == (int)(*i).second.size()) {
-				out.push_back((*i).first);
+			if(count == (int)i->second.size()) {
+				out.push_back(i->first);
 			}
 		}
 	}
@@ -171,19 +171,16 @@ vector<string> GraphColoring::Lmxrlf::uncolored_neighbor(vector<string> new_set)
 }
 
 map<string,int> GraphColoring::Lmxrlf::lmxrlf_alg(int endcond) {
-	map< string, vector<string> > Graph_temp;
-	vector< vector<string> > list_of_best_solutions;
+	map<string,vector<string>> Graph_temp;
+	vector<vector<string>> list_of_best_solutions;
 	srand(time(NULL));
 	int colored_nodes = 0;
-	int Color = 0;
-	for(map< string,int >::iterator i = graph_colors.begin(); i != graph_colors.end(); i++) {
-		if((*i).second != -1) {
+	for(map<string,int>::iterator i = graph_colors.begin(); i != graph_colors.end(); i++) {
+		if(i->second != -1) {
 			colored_nodes += 1;
 		}
-		if((*i).second > Color) {
-			Color = (*i).second;
-		}
 	}
+    int Color = this->get_num_colors() - 1;
 	if(Color > 0) { Color += 1; }
 	do {
 		int global_iterations;
@@ -211,7 +208,6 @@ map<string,int> GraphColoring::Lmxrlf::lmxrlf_alg(int endcond) {
 			}
 		}
 		for(unsigned i=0; i<list_of_best_solutions.size(); i++) {
-			int flag = 0;
 			vector<string> S_plus = list_of_best_solutions[i];
 			for(int j=0; j<this->local; j++) {
 				//remove random vertices from S_star
@@ -228,7 +224,6 @@ map<string,int> GraphColoring::Lmxrlf::lmxrlf_alg(int endcond) {
 				//Check ObjF of S_star and add if smaller than original
 				if(objf(S_star) > objf(S_plus)) {
 					S_plus = S_star;
-					flag = 1;//TODO: flag is never used?
 				}
 			}
 			list_of_best_solutions[i] = S_plus;
@@ -257,15 +252,15 @@ map<string,int> GraphColoring::Lmxrlf::lmxrlf_alg(int endcond) {
 			}
 		}
 		Color += 1;
-	} while(colored_nodes < endcond-1);
-	return graph_colors;
+	} while(colored_nodes < endcond);
+	return this->graph_colors;
 }
 
 //Runs LMXRLF starting with a fully uncolored graph
 map<string,int> GraphColoring::Lmxrlf::color() {
 	if (this->condition == 0) { this->condition = graph.size(); }
-	for(map< string, vector<string> >::iterator i = graph.begin(); i != graph.end(); i++) {
-		graph_colors[(*i).first] = -1;
+	for(map<string, vector<string>>::iterator i = graph.begin(); i != graph.end(); i++) {
+		this->graph_colors[i->first] = -1;
 	}
 	return lmxrlf_alg(this->condition);
 }

--- a/Tests/lmxrlf_tests.cpp
+++ b/Tests/lmxrlf_tests.cpp
@@ -5,7 +5,7 @@
 
 using GraphColoring::Lmxrlf;
 
-TEST(LmxrlfTests, LmxrlfK55ColorTest) {
+TEST(LmxrlfTests, LmxrlfK5ColorTest) {
     vector<string> node_k1 = { "k2", "k3", "k4", "k5" };
     vector<string> node_k2 = { "k1", "k3", "k4", "k5" };
     vector<string> node_k3 = { "k1", "k2", "k4", "k5" };
@@ -16,5 +16,16 @@ TEST(LmxrlfTests, LmxrlfK55ColorTest) {
     Lmxrlf* lmxrlf = new Lmxrlf(k5);
     map<string,int> resultant = lmxrlf->color();
     EXPECT_EQ(lmxrlf->get_num_colors(),5);
+    delete lmxrlf;
+}
+
+TEST(LmxrlfTests, LmxrlfK33ColorTest) {
+    vector<string> side_a = { "k4", "k5", "k6" };
+    vector<string> side_b = { "k1", "k2", "k3" };
+    map<string,vector<string>> k33 = { {"k1", side_a}, {"k2", side_a}, {"k3", side_a}, {"k4", side_b}, {"k5", side_b}, {"k6", side_b} };
+    
+    Lmxrlf* lmxrlf = new Lmxrlf(k33);
+    map<string,int> resultant = lmxrlf->color();
+    EXPECT_EQ(lmxrlf->get_num_colors(),2);
     delete lmxrlf;
 }


### PR DESCRIPTION
Fixes the ending condition for the LXMRLF algorithm so that it fully colors the graph rather than missing the last node. Additionally, it generally cleans up the LXMRLF code to be slightly more presentable. This patch should have additional tests added to it to make sure that its a full fix to the issue, and if it is the ending condition should be refactored to better describe what is actually happening.