### PR TITLE
Fix Tabucol Regression

### DIFF
--- a/Source/tabucol.cpp
+++ b/Source/tabucol.cpp
@@ -14,7 +14,7 @@ using std::cout;
 GraphColoring::Tabucol::Tabucol(map<string, vector<string> > graph, int condition, int tabu_size, int rep, int nbmax) : GraphColor(graph) {
     if(condition > this->graph.size()) {
         this->condition = this->graph.size();
-    } else { 
+    } else {
         this->condition = condition;
     }
     this->tabu_size = tabu_size;
@@ -26,7 +26,7 @@ int GraphColoring::Tabucol::f(map<string,int> graph_colors) {
     int sum = 0;
     for(map< string,vector<string> >::iterator i = this->graph.begin(); i != this->graph.end(); i++) {
         for(unsigned j = 0; j< i->second.size(); j++) {
-            if(this->graph_colors[i->first] == this->graph_colors[i->second[j]]) {
+            if(graph_colors[i->first] == graph_colors[i->second[j]]) {
                 sum += 1;
             }
         }
@@ -144,4 +144,3 @@ map<string,int> GraphColoring::Tabucol::color() {
 
     return graph_colors;
 }
-


### PR DESCRIPTION
Fix Tabucol regression introduced at https://github.com/brrcrites/graph-coloring/commit/1b7397cf548130b69895838cd9d3241c144aa6a8#diff-8d7e60d4e0226ddd8ea94e49005645c0R23
This prevented the local improvement from updating the solution https://github.com/brrcrites/graph-coloring/commit/1b7397cf548130b69895838cd9d3241c144aa6a8#diff-8d7e60d4e0226ddd8ea94e49005645c0R83

This has prevented previously colorable bipartite graph to be colored with 2 colors. The coloring failed on a K8,8 with 40% connected bipartite graph. It is harder to reproduce in a small test set. Therefore, I did not include a test case in this PR.