### PR TITLE
Convert atoi -> stoi, update CLI to use MSC by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@
 *.exe
 *.out
 *.app
+color
+color-test
 
 # Vim
 *.swp
@@ -42,5 +44,5 @@ CMakeFiles/
 Makefile
 *.dylib
 
-color
-color-test
+# VS Code
+.vscode

--- a/Header/parse.hpp
+++ b/Header/parse.hpp
@@ -77,7 +77,7 @@ map<string,vector<string>> parse_edge_list(string input_file) {
             vector<string> words = split(line);
             if(words.size() != 0) {
                 if(words[0] == "p") {
-                    vertices = atoi(words[2].c_str());
+                    vertices = stoi(words[2]);
                     flag = 1;
                 }
             }
@@ -128,7 +128,7 @@ map<string,vector<string>> parse_edge_matrix(string input_file) {
     if(file.is_open()) {
         string line;
         Getline(file,line);
-        int n = atoi(line.c_str());
+        int n = stoi(line);
         int i = 0;
         while(Getline(file,line)) {
             i += 1;

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ Five coloring algorithms are currently provided in this package (See reference p
 - DSATUR (New Methods to Color the Vertices of a Graph - Brelaz et al.) -- `--algorithm=ssatur`
 - MCS (Register Allocation via Coloring of Chordal Graphs - Magno et al.) -- `--algorithm=mcs`
 - lmXRLF (Efficient Coloring of a Large Spectrum of Graphs - Kirovski et al.) -- `--algorithm=lmxrlf`
-- Hybrid DSATUR (Custom, based on Efficient Coloring... - Kirovski et al.) -- `--hybrid dsatur`
-- Hybrid lmXRLF (Custom, based on Efficient Coloring... - Kirovski et al.) -- `--algorithm=hybrid lmxrlf`
+- Hybrid DSATUR (Custom, based on Efficient Coloring... - Kirovski et al.) -- `--hybrid-dsatur`
+- Hybrid lmXRLF (Custom, based on Efficient Coloring... - Kirovski et al.) -- `--algorithm=hybrid-lmxrlf`
 
 Additionally, there is a k-coloring algorithm that is accessible, and used internally within other algorithms:
 

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -23,7 +23,7 @@ using GraphColoring::HybridLmxrlf;
 using GraphColoring::GraphColor;
 
 DEFINE_string(graph, "", "The path to the graph file to be colored");
-DEFINE_string(algorithm, "hybrid dsatur", "The algorithm to execute on chosen benchmark (dsatur, mcs, lmxrlf, hybrid dsatur, hybrid lmxrlf)");
+DEFINE_string(algorithm, "mcs", "The algorithm to execute on chosen benchmark (dsatur, mcs, lmxrlf, hybrid dsatur, hybrid lmxrlf)");
 DEFINE_string(format, "", "The format of the input graph to be parsed (matrix, list)");
 
 GraphColor* parse_algorithm_flag(map<string,vector<string>> graph) {
@@ -33,9 +33,9 @@ GraphColor* parse_algorithm_flag(map<string,vector<string>> graph) {
         return new Mcs(graph);
     } else if(FLAGS_algorithm == "lmxrlf") {
         return new Lmxrlf(graph);
-    } else if(FLAGS_algorithm == "hybrid dsatur") {
+    } else if(FLAGS_algorithm == "hybrid-dsatur") {
         return new HybridDsatur(graph);
-    } else if(FLAGS_algorithm == "hybird lmxrlf") {
+    } else if(FLAGS_algorithm == "hybird-lmxrlf") {
         return new HybridLmxrlf(graph);
     }
     return nullptr;
@@ -45,7 +45,7 @@ int main(int argc, char** argv) {
     gflags::ParseCommandLineFlags(&argc, &argv, true);
 
     string banner = "This program attempts to color an input graph using one of the available coloring algorithms";
-    string usage = "\tUsage: ./color --graph=path_to_graph --format=(matrix|list) [--algorithm=(dsatur|mcs|lmxrlf|hybrid dsatur|hybrid lmxrlf)]";
+    string usage = "\tUsage: ./color --graph=path_to_graph --format=(m[atrix]|l[ist]) [--algorithm=(dsatur|mcs|lmxrlf|hybrid-dsatur|hybrid-lmxrlf)]";
     gflags::SetUsageMessage(banner + "\n" + usage);
 
     if(FLAGS_graph == "") {
@@ -54,9 +54,9 @@ int main(int argc, char** argv) {
     }
 
     map<string,vector<string>> input_graph;
-    if(FLAGS_format == "matrix") {
+    if(FLAGS_format == "matrix" || FLAGS_format == "m") {
         input_graph = parse_edge_matrix(FLAGS_graph);
-    } else if(FLAGS_format == "list") {
+    } else if(FLAGS_format == "list" || FLAGS_format == "l") {
         input_graph = parse_edge_list(FLAGS_graph);
     } else {
         gflags::ShowUsageWithFlags(argv[0]);


### PR DESCRIPTION
* Updates the parse.hpp file to use `stoi` c++11 function which checks the input rather than the antiquated `atoi`
* Updates the CLI so the default algorithm will be MSC rather than one of the currently broken hybrid methods